### PR TITLE
fix: getOutput function

### DIFF
--- a/src/components/minimal-tiptap/utils.ts
+++ b/src/components/minimal-tiptap/utils.ts
@@ -39,7 +39,7 @@ export const getOutput = (editor: Editor, format: MinimalTiptapProps['output']):
     case 'json':
       return editor.getJSON()
     case 'html':
-      return editor.getText() ? editor.getHTML() : ''
+      return editor.isEmpty ? '' : editor.getHTML()
     default:
       return editor.getText()
   }


### PR DESCRIPTION
Resolved an issue in `getOutput` where an empty value was returned if no text nodes were present.