### PR TITLE
fix: Returns focus to editor on dropdown close instead of dropdown trigger

### DIFF
--- a/src/components/minimal-tiptap/components/section/one.tsx
+++ b/src/components/minimal-tiptap/components/section/one.tsx
@@ -124,7 +124,7 @@ export const SectionOne: React.FC<SectionOneProps> = React.memo(
             <CaretDownIcon className="size-5" />
           </ToolbarButton>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-full">
+        <DropdownMenuContent align="start" className="w-full" onCloseAutoFocus={(e) => e.preventDefault()}>
           {filteredActions.map(renderMenuItem)}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/minimal-tiptap/components/toolbar-section.tsx
+++ b/src/components/minimal-tiptap/components/toolbar-section.tsx
@@ -100,7 +100,7 @@ export const ToolbarSection: React.FC<ToolbarSectionProps> = ({
               {dropdownIcon || <CaretDownIcon className="size-5" />}
             </ToolbarButton>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-full">
+          <DropdownMenuContent align="start" className="w-full" onCloseAutoFocus={(e) => e.preventDefault()}>
             {dropdownActions.map(renderDropdownMenuItem)}
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
The tiptap logic for the text size selector drop down and the same logic in the dropdown for the list style selector currently doesn't work. The editor does actually put focus back on the editor correctly, but due to a race condition with the ShadCn Dropdown component, it doesn't stay there. Instead the focus gets put back on the Dropdown trigger. This is a jarring experience if you're just trying to author a document.

Following the [shadCn DropdownMenu API docs suggestion](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#api-reference) I've added a `preventDefault` to the `onCloseAutoFocus` prop to prevent the `Dropdown` from trying to control the focus state on close.