### PR TITLE
fix(css): only the first line display placeholder

### DIFF
--- a/src/components/minimal-tiptap/styles/partials/placeholder.css
+++ b/src/components/minimal-tiptap/styles/partials/placeholder.css
@@ -1,4 +1,4 @@
-.minimal-tiptap-editor .ProseMirror > p.is-editor-empty::before {
+.minimal-tiptap-editor .ProseMirror > p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   @apply pointer-events-none float-left h-0 text-[var(--mt-secondary)];
 }


### PR DESCRIPTION
There is a little css bug: when user hit enter before any input in the editor, the placeholder will move to next line. (as the picture below)

This PR fixes it.

![image](https://github.com/user-attachments/assets/57d7bd2d-e19d-4f2d-b1f0-15b28f3ab15e)
