### PR TITLE
Fix: prevent image duplication when pasting between lines

### DIFF
--- a/src/components/minimal-tiptap/extensions/file-handler/index.ts
+++ b/src/components/minimal-tiptap/extensions/file-handler/index.ts
@@ -27,14 +27,14 @@ const FileHandlePlugin = (options: FileHandlePluginOptions) => {
 
     props: {
       handleDrop(view, event) {
-        event.preventDefault()
-        event.stopPropagation()
-
         const { dataTransfer } = event
 
         if (!dataTransfer?.files.length) {
-          return
+          return false
         }
+
+        event.preventDefault()
+        event.stopPropagation()
 
         const pos = view.posAtCoords({
           left: event.clientX,
@@ -57,17 +57,19 @@ const FileHandlePlugin = (options: FileHandlePluginOptions) => {
         if (validFiles.length > 0 && onDrop) {
           onDrop(editor, validFiles, pos?.pos ?? 0)
         }
+
+        return true
       },
 
       handlePaste(_, event) {
-        event.preventDefault()
-        event.stopPropagation()
-
         const { clipboardData } = event
 
         if (!clipboardData?.files.length) {
-          return
+          return false
         }
+
+        event.preventDefault()
+        event.stopPropagation()
 
         const [validFiles, errors] = filterFiles(
           Array.from(clipboardData.files),
@@ -86,6 +88,8 @@ const FileHandlePlugin = (options: FileHandlePluginOptions) => {
         if (validFiles.length > 0 && onPaste) {
           onPaste(editor, validFiles, html)
         }
+
+        return true
       },
     },
   })


### PR DESCRIPTION
Fix for #47 

When pasting an image, it gets duplicated because `handlePaste` doesn't return an explicit value after handling files. Without returning `true` other handlers also process the same paste event. Applied the same fix to `handleDrop` for consistency.